### PR TITLE
fix: wrapping in gol demo

### DIFF
--- a/demos/gameoflife.asm
+++ b/demos/gameoflife.asm
@@ -10,24 +10,102 @@ start:
 cycle:
   mov %r1, 0
   game_loop:
-    ; this doesnt wrap around "correctly" at edges but is convincing enough
-    lbu %r3, %r1, 0xbf7f ; up left
+    add %r4, %r1, 0xbf7f
+    cmp %r4, 0xc000
+    jge out1
+    add %r4, %r4, 0x3000
+  out1:
+    cmp %r4, 0xefff
+    jle out2
+    sub %r4, %r4, 0x3000
+  out2:
+    lbu %r3, %r4, 0 ; up left
     add %r2, %r0, %r3
-    lbu %r3, %r1, 0xbf80 ; up
+
+    add %r4, %r1, 0xbf80
+    cmp %r4, 0xc000
+    jge out3
+    add %r4, %r4, 0x3000
+  out3:
+    cmp %r4, 0xefff
+    jle out4
+    sub %r4, %r4, 0x3000
+  out4:
+    lbu %r3, %r4, 0 ; up
     add %r2, %r2, %r3
-    lbu %r3, %r1, 0xbf81 ; up right
+
+    add %r4, %r1, 0xbf81
+    cmp %r4, 0xc000
+    jge out5
+    add %r4, %r4, 0x3000
+  out5:
+    cmp %r4, 0xefff
+    jle out6
+    sub %r4, %r4, 0x3000
+  out6:
+    lbu %r3, %r4, 0 ; up right
     add %r2, %r2, %r3
-    lbu %r3, %r1, 0xbfff ; left
+
+    add %r4, %r1, 0xbfff
+    cmp %r4, 0xc000
+    jge out7
+    add %r4, %r4, 0x3000
+  out7:
+    cmp %r4, 0xefff
+    jle out8
+    sub %r4, %r4, 0x3000
+  out8:
+    lbu %r3, %r4, 0 ; left
     add %r2, %r2, %r3
-    lbu %r3, %r1, 0xc001 ; right
+
+    add %r4, %r1, 0xc001
+    cmp %r4, 0xc000
+    jge out9
+    add %r4, %r4, 0x3000
+  out9:
+    cmp %r4, 0xefff
+    jle out10
+    sub %r4, %r4, 0x3000
+  out10:
+    lbu %r3, %r4, 0  ; right
     add %r2, %r2, %r3
-    lbu %r3, %r1, 0xc07f ; down left
+
+    add %r4, %r1, 0xc07f
+    cmp %r4, 0xc000
+    jge out11
+    add %r4, %r4, 0x3000
+  out11:
+    cmp %r4, 0xefff
+    jle out12
+    sub %r4, %r4, 0x3000
+  out12:
+    lbu %r3, %r4, 0 ; down left
     add %r2, %r2, %r3
-    lbu %r3, %r1, 0xc080 ; down
+
+    add %r4, %r1, 0xc080
+    cmp %r4, 0xc000
+    jge out13
+    add %r4, %r4, 0x3000
+  out13:
+    cmp %r4, 0xefff
+    jle out14
+    sub %r4, %r4, 0x3000
+  out14:
+    lbu %r3, %r4, 0 ; down
     add %r2, %r2, %r3
-    lbu %r3, %r1, 0xc081 ; down right
+
+    add %r4, %r1, 0xc081
+    cmp %r4, 0xc000
+    jge out15
+    add %r4, %r4, 0x3000
+  out15:
+    cmp %r4, 0xefff
+    jle out16
+    sub %r4, %r4, 0x3000
+  out16:
+    lbu %r3, %r4, 0 ; down right
     add %r2, %r2, %r3
-     
+
     lbu %r3, %r1, 0xc000
     cmp %r2, 0x1fe ; 2 * 0xff
     jeq continue
@@ -39,7 +117,7 @@ cycle:
     mov %r3, 0
     continue:
     sb %r3, %r1, 0x2000
-  
+
     inc %r1
     cmp %r1, 0x3000
     jne game_loop
@@ -53,5 +131,5 @@ cycle:
     add %r1, %r1, 2
     cmp %r1, 0x3000
     jne blit_loop
-     
+
   jmp cycle

--- a/demos/gameoflife.asm
+++ b/demos/gameoflife.asm
@@ -11,98 +11,50 @@ cycle:
   mov %r1, 0
   game_loop:
     add %r4, %r1, 0xbf7f
-    cmp %r4, 0xc000
-    jge out1
-    add %r4, %r4, 0x3000
-  out1:
-    cmp %r4, 0xefff
-    jle out2
-    sub %r4, %r4, 0x3000
-  out2:
+    add %ra, %pc, 4
+    jmp wrap_r4
     lbu %r3, %r4, 0 ; up left
     add %r2, %r0, %r3
 
     add %r4, %r1, 0xbf80
-    cmp %r4, 0xc000
-    jge out3
-    add %r4, %r4, 0x3000
-  out3:
-    cmp %r4, 0xefff
-    jle out4
-    sub %r4, %r4, 0x3000
-  out4:
+    add %ra, %pc, 4
+    jmp wrap_r4
     lbu %r3, %r4, 0 ; up
     add %r2, %r2, %r3
 
     add %r4, %r1, 0xbf81
-    cmp %r4, 0xc000
-    jge out5
-    add %r4, %r4, 0x3000
-  out5:
-    cmp %r4, 0xefff
-    jle out6
-    sub %r4, %r4, 0x3000
-  out6:
+    add %ra, %pc, 4
+    jmp wrap_r4
     lbu %r3, %r4, 0 ; up right
     add %r2, %r2, %r3
 
     add %r4, %r1, 0xbfff
-    cmp %r4, 0xc000
-    jge out7
-    add %r4, %r4, 0x3000
-  out7:
-    cmp %r4, 0xefff
-    jle out8
-    sub %r4, %r4, 0x3000
-  out8:
+    add %ra, %pc, 4
+    jmp wrap_r4
     lbu %r3, %r4, 0 ; left
     add %r2, %r2, %r3
 
     add %r4, %r1, 0xc001
-    cmp %r4, 0xc000
-    jge out9
-    add %r4, %r4, 0x3000
-  out9:
-    cmp %r4, 0xefff
-    jle out10
-    sub %r4, %r4, 0x3000
-  out10:
+    add %ra, %pc, 4
+    jmp wrap_r4
     lbu %r3, %r4, 0  ; right
     add %r2, %r2, %r3
 
     add %r4, %r1, 0xc07f
-    cmp %r4, 0xc000
-    jge out11
-    add %r4, %r4, 0x3000
-  out11:
-    cmp %r4, 0xefff
-    jle out12
-    sub %r4, %r4, 0x3000
-  out12:
+    add %ra, %pc, 4
+    jmp wrap_r4
     lbu %r3, %r4, 0 ; down left
     add %r2, %r2, %r3
 
     add %r4, %r1, 0xc080
-    cmp %r4, 0xc000
-    jge out13
-    add %r4, %r4, 0x3000
-  out13:
-    cmp %r4, 0xefff
-    jle out14
-    sub %r4, %r4, 0x3000
-  out14:
+    add %ra, %pc, 4
+    jmp wrap_r4
     lbu %r3, %r4, 0 ; down
     add %r2, %r2, %r3
 
     add %r4, %r1, 0xc081
-    cmp %r4, 0xc000
-    jge out15
-    add %r4, %r4, 0x3000
-  out15:
-    cmp %r4, 0xefff
-    jle out16
-    sub %r4, %r4, 0x3000
-  out16:
+    add %ra, %pc, 4
+    jmp wrap_r4
     lbu %r3, %r4, 0 ; down right
     add %r2, %r2, %r3
 
@@ -133,3 +85,14 @@ cycle:
     jne blit_loop
 
   jmp cycle
+
+wrap_r4:
+    cmp %r4, 0xc000
+    jge out1
+    add %r4, %r4, 0x3000
+  out1:
+    cmp %r4, 0xefff
+    jle out2
+    sub %r4, %r4, 0x3000
+  out2:
+    jmp %ra

--- a/q16/src/asm.rs
+++ b/q16/src/asm.rs
@@ -62,7 +62,7 @@ impl Assembler {
           err!("'{}' requires 2 or 3 operands, found {}", mnemonic, operands.len())
         }
       }
-      Ok(opc @ (Opcode::Jeq | Opcode::Jne | Opcode::Jgt | Opcode::Jlt)) => {
+      Ok(opc @ (Opcode::Jeq | Opcode::Jne | Opcode::Jgt | Opcode::Jlt | Opcode::Jge | Opcode::Jle)) => {
         if operands.len() == 2 {
           self.assemble_2(opc, &operands)
         } else if operands.len() == 1 {

--- a/q16/src/emu.rs
+++ b/q16/src/emu.rs
@@ -94,6 +94,16 @@ impl Emulator {
           self.registers.pc = self.get_i_addr(instr)
         }
       }
+      Opcode::Jge => {
+        if !get_bit(self.registers.sts, sts::NEG) {
+          self.registers.pc = self.get_i_addr(instr);
+        }
+      }
+      Opcode::Jle => {
+        if get_bit(self.registers.sts, sts::NEG) || get_bit(self.registers.sts, sts::ZERO) {
+          self.registers.pc = self.get_i_addr(instr);
+        }
+      }
     };
     output
   }

--- a/q16/src/lib.rs
+++ b/q16/src/lib.rs
@@ -48,6 +48,8 @@ pub enum Opcode {
   Jne,
   Jgt,
   Jlt,
+  Jge,
+  Jle,
 }
 
 impl Opcode {


### PR DESCRIPTION
This PR does the following: 

- Adds the jge and jle mnemonics (I'm not sure if they're even correct as you said, but the GOL demo works with them so I'll assume they're correct :>)
- Adds wrapping for the GOL demo